### PR TITLE
[5] 재할당

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,6 +1,6 @@
 const vscode = require("vscode");
 const selector = require("./src/selector");
-const provider = require("./src/provider");
+const Provider = require("./src/provider");
 const { legend } = require("./src/legend");
 
 /**
@@ -11,7 +11,7 @@ function activate(context) {
   context.subscriptions.push(
     vscode.languages.registerDocumentSemanticTokensProvider(
       selector,
-      provider,
+      Provider,
       legend
     )
   );

--- a/src/cleanUp.js
+++ b/src/cleanUp.js
@@ -1,22 +1,34 @@
 function validateLine(text, isCommenting) {
   if (!text) {
-    return [true, isCommenting];
+    return {
+      isSkip: true,
+      isCommenting,
+    };
   }
 
   if (text.trim().indexOf("//") === 0) {
-    return [true, isCommenting];
+    return {
+      isSkip: true,
+      isCommenting,
+    };
   }
 
   if (
     text.trim().indexOf("/*") === 0 &&
     text.trim().indexOf("*/") === text.trim().length - 2
   ) {
-    return [true, isCommenting];
+    return {
+      isSkip: true,
+      isCommenting,
+    };
   }
 
   if (text.trim().indexOf("/*") === 0 && !text.includes("*/")) {
     isCommenting = true;
-    return [true, isCommenting];
+    return {
+      isSkip: true,
+      isCommenting: true,
+    };
   }
 
   if (
@@ -25,7 +37,10 @@ function validateLine(text, isCommenting) {
     !text.split("*/")[1].trim()
   ) {
     isCommenting = false;
-    return [true, isCommenting];
+    return {
+      isSkip: true,
+      isCommenting: false,
+    };
   }
 
   if (
@@ -36,7 +51,10 @@ function validateLine(text, isCommenting) {
     isCommenting = false;
   }
 
-  return [false, isCommenting];
+  return {
+    isSkip: false,
+    isCommenting,
+  };
 }
 
 function trimBlankText(text) {
@@ -55,7 +73,10 @@ function trimBlankText(text) {
     }
   }
 
-  return [splitedTextArray.join(" "), count];
+  return {
+    line: splitedTextArray.join(" "),
+    count,
+  };
 }
 
 function removeComment(text, currentOffset) {
@@ -63,17 +84,26 @@ function removeComment(text, currentOffset) {
   let count = currentOffset;
 
   if (isSlashComment) {
-    return [text.split(";")[0] + ";", count];
+    return {
+      line: text.split(";")[0] + ";",
+      count,
+    };
   }
 
   const isBlockComment = text.includes("*/");
 
   if (isBlockComment) {
     count += text.indexOf(text.split("*/")[1].trimStart());
-    return [text.split("*/")[1].trimStart(), count];
+    return {
+      line: text.split("*/")[1].trimStart(),
+      count,
+    };
   }
 
-  return [text, count];
+  return {
+    line: text,
+    count,
+  };
 }
 
 exports.validateLine = validateLine;

--- a/src/legend.js
+++ b/src/legend.js
@@ -18,6 +18,7 @@ const legend = (function () {
     "undefined",
     "array",
     "object",
+    "not_defined",
   ];
 
   tokenModifiersLegend.forEach((tokenModifier, index) =>

--- a/src/provider.js
+++ b/src/provider.js
@@ -3,8 +3,8 @@ const { tokenTypes, tokenModifiers } = require("./legend");
 const { checkBooleanType, checkNumberType } = require("./type");
 const { validateLine, trimBlankText, removeComment } = require("./cleanUp");
 
-const document = {};
-const helper = helpProvider();
+let document = {};
+const helper = createHelper();
 const provider = createProvider();
 
 function createProvider() {
@@ -59,16 +59,6 @@ function createProvider() {
     return result;
   }
 
-  function validateType(value) {
-    if (checkBooleanType(value)) {
-      tokenData = parseToken("boolean");
-    } else if (checkNumberType(value)) {
-      tokenData = parseToken("number");
-    }
-
-    return tokenData;
-  }
-
   function parseToken(type) {
     return {
       tokenType: "type",
@@ -86,9 +76,9 @@ function createProvider() {
         tempParsedText.value += lines[i];
 
         if (lines[i].includes(";")) {
-          const validatedTypeResult = validateType(tempParsedText.value);
+          tokenData = helper.validateType(tempParsedText.value);
 
-          if (validatedTypeResult) {
+          if (tokenData) {
             results.push({
               line: tempParsedText.line,
               startCharacter: tempParsedText.startCharacter,
@@ -102,11 +92,14 @@ function createProvider() {
           isContinue = false;
         }
 
+        helper.validateLastline(i, lines.length);
         continue;
       } else if (isContinue && !lines[i]) {
+        helper.validateLastline(i, lines.length);
         continue;
       }
 
+      // tokenData, currentOffset 초기화
       tokenData = null;
       currentOffset = 0;
 
@@ -116,6 +109,7 @@ function createProvider() {
       isCommenting = validatedLineResults.isCommenting;
 
       if (isSkip || isCommenting) {
+        helper.validateLastline(i, lines.length);
         continue;
       }
 
@@ -134,12 +128,12 @@ function createProvider() {
       const declarationArea = convertedLineArray[0].split(" ");
       const definitionArea = convertedLineArray[1].trim();
 
-      // 변수 시작 , 종료 포지션
+      // 변수 시작 , 종료 위치
       let startPos = currentOffset + declarationArea[0].length + 1;
       const endPos = startPos + declarationArea[1].length;
 
       // 변수의 값으로 Type 체크 tokenData 생성
-      validateType(definitionArea);
+      tokenData = helper.validateType(definitionArea);
 
       // Number Multiline 경우
       if (!definitionArea.includes(";")) {
@@ -149,13 +143,11 @@ function createProvider() {
         tempParsedText.value = definitionArea;
 
         isContinue = true;
-
+        helper.validateLastline(i, lines.length);
         continue;
       }
 
       // if : 변수 초기선언시 const , var , let -> parsing
-      // else if :  이미 선언된 변수 , const인 변수는 로직을 수행하지 못하도록 startPos 조정
-      // else if : 변수 = 변수를 할당할 때
       if (
         declarationArea[0] === "var" ||
         declarationArea[0] === "let" ||
@@ -180,6 +172,7 @@ function createProvider() {
         document[declarationArea[0]][0].statement !== "const" &&
         tokenData
       ) {
+        // else if :  이미 선언된 변수 , const인 변수는 로직을 수행하지 못하도록 startPos 조정
         const variableName = declarationArea[0];
         startPos = endPos - variableName.length - 1;
 
@@ -192,21 +185,33 @@ function createProvider() {
           tokenData,
         });
       } else if (document[declarationArea.slice(0, -1)] && !tokenData) {
+        // else if : 변수 = 변수를 할당할 때 -> 선언 O 변수 , 선언 X 변수
+        const variableInValue = definitionArea.slice(0, -1);
         const variableName = declarationArea[0];
-        const latestVariableInfo =
-          document[variableName][document[variableName].length - 1];
+        let latestVariableInfo = null;
 
-        startPos = endPos - variableName.length - 1;
-        tokenData = latestVariableInfo.tokenData;
+        if (document[variableInValue]) {
+          latestVariableInfo = document[variableInValue].slice(-1)[0];
+          startPos = endPos - variableName.length - 1;
+          tokenData = latestVariableInfo.tokenData;
 
-        document[variableName].push({
-          value: definitionArea,
-          line: i,
-          startPos,
-          endPos,
-          length: endPos - startPos,
-          tokenData,
-        });
+          document[variableName].push({
+            value: definitionArea,
+            line: i,
+            startPos,
+            endPos,
+            length: endPos - startPos,
+            tokenData,
+          });
+          console.log("\n");
+          console.log("variable :::::", declarationArea);
+          console.log("value :::::", definitionArea);
+          console.log("line :::::", i);
+          console.log("offset :::::", currentOffset);
+          console.log("start :::::", startPos - declarationArea[0].length);
+          console.log("end :::::", endPos);
+          console.log("tokenData :::::", tokenData);
+        }
       }
 
       if (tokenData) {
@@ -218,6 +223,8 @@ function createProvider() {
           tokenModifiers: tokenData.tokenModifiers,
         });
       }
+
+      helper.validateLastline(i, lines.length);
     }
 
     return results;
@@ -225,11 +232,36 @@ function createProvider() {
 
   return {
     provideDocumentSemanticTokens,
+    encodeTokenModifiers,
+    encodeTokenType,
+    parseText,
+    parseToken,
   };
 }
 
-function helpProvider() {
-  return {};
+function createHelper() {
+  function validateType(value) {
+    let tokenData = null;
+
+    if (checkBooleanType(value)) {
+      tokenData = provider.parseToken("boolean");
+    } else if (checkNumberType(value)) {
+      tokenData = provider.parseToken("number");
+    }
+
+    return tokenData;
+  }
+
+  function validateLastline(lineNumber, totalLength) {
+    if (lineNumber === totalLength - 1) {
+      document = {};
+    }
+  }
+
+  return {
+    validateType,
+    validateLastline,
+  };
 }
 
 module.exports = provider;
@@ -241,6 +273,3 @@ module.exports = provider;
 // console.log("offset :::::", currentOffset);
 // console.log("start :::::", startPos - declarationArea[0].length);
 // console.log("end :::::", endPos);
-// console.log("validatedTypeResult :::::", validatedTypeResult);
-// console.log("latestVariableInfo", latestVariableInfo);
-// console.log(document[declarationArea.slice(0, -1)]);

--- a/src/type.js
+++ b/src/type.js
@@ -1,11 +1,5 @@
 function checkBooleanType(value) {
-  if (
-    value === "true;" ||
-    value === "true" ||
-    value === "false;" ||
-    value === "false" ||
-    value.includes("!")
-  ) {
+  if (value === "true;" || value === "false;" || value.includes("!")) {
     return true;
   }
 


### PR DESCRIPTION
## Description

[5] 재할당
(https://www.notion.so/9ce61f91ac06479ba23d4294585c76c0?v=ec131339ba4549d4954d0c49bbd71f00&p=9a7a7757b8484778a2e50f8542701967)

##작업상세
— var , let , const  -> 각 줄의 정보를 parsing

— 값의 재할당은 기존 로직으로 token 맵핑 구현
```
let num1 = 100;

num1 = true; // num1을 불린타입으로 맵핑
```

— 값에서 변수 사용시 해당 변수의 token으로 맵핑 되도록 로직 구현
```
let bool1 = true;
let num1 = 101111;

num1 = bool1; // num1을 bool1의 타입인 boolean 으로 맵핑
```

— 변수 선언전 할당  로직 구현
	1 . var :  undefined
	2 . let : 에러이니 처리하지 않아도 됨
```
let bool1 = true;
var bool2 = false;

bool1 = num1; // 아래에서 let으로 선언된 변수이므로 not_defined 에러 처리 어두운색 밑줄처리
bool2 = num2; // 아래에서 var로 선언된 변수이므로 undefined 타입으로 처리

let num1 = 101111;
var num2 = 7;
```
